### PR TITLE
Added Linux ARM64 build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ build-all:
 	GOOS=linux GOARCH=amd64 go build -o $(OUTPUT_DIR)/darkflare-client-linux-amd64 client/main.go
 	GOOS=linux GOARCH=amd64 go build -o $(OUTPUT_DIR)/darkflare-server-linux-amd64 server/main.go
 	
+	# Linux ARM64 (aarch64)
+	GOOS=linux GOARCH=arm64 go build -o $(OUTPUT_DIR)/darkflare-client-linux-arm64 client/main.go
+	GOOS=linux GOARCH=arm64 go build -o $(OUTPUT_DIR)/darkflare-server-linux-arm64 server/main.go
+	
 	# macOS AMD64 (Intel)
 	GOOS=darwin GOARCH=amd64 go build -o $(OUTPUT_DIR)/darkflare-client-darwin-amd64 client/main.go
 	GOOS=darwin GOARCH=amd64 go build -o $(OUTPUT_DIR)/darkflare-server-darwin-amd64 server/main.go


### PR DESCRIPTION
# Add Linux ARM64 Build Support

## Summary
This PR introduces support for building `darkflare-client` and `darkflare-server` on Linux ARM64 (aarch64). This ensures compatibility with ARM-based systems.

## Note
Binaries were intentionally excluded from the commit to avoid any potential supply chain concerns.

## Next Steps
Is there any reason this couldn’t be merged? Let me know if changes are needed, and I’ll address them promptly.